### PR TITLE
add a formal structure for this document, similar to RFCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,11 @@ eavesdropper can do that for several peers, then they may perform a metadata
 analysis attack where they try to correlate the encrypted messages on the shard
 feeds to the group members.
 
+In the current implementation, we mitigated through how shards are assigned
+per user - because the derivation involves a hash function and a piece of
+content unique to the peer (their root feed id), each peer will have the group
+located in a different shard. This makes it harder to guess which group an 
+announce message was for. 
 This can be mitigated by publishing dummy encrypted messages on the shard feed
 at random intervals, with the downside of increasing the size of the shard feed,
 and thus making partial replication heavier.

--- a/README.md
+++ b/README.md
@@ -94,33 +94,17 @@ messages encrypted with [envelope-spec] encryption
 #### `group/add-member` messages
 
 This is the only type of message currently expected in the additions feed.
-It's defined in the [private-group-spec] to look like this:
+It's defined in the [private-group-spec] and MUST have at least the following
+fields in its message `content`:
 
-```js
-{
-  type: 'group/add-member',
-  version: 'v2',
-  root: 'ssb:message/classic/THxjTGPuXvvxnbnAV7xVuVXdhDcmoNtDDN0j3UTxcd8=',
-  secret: '3YUat1ylIUVGaCjotAvof09DhyFxE8iGbF6QxLlCWWc=',
-  recps: [
-    'ssb:identity/group/vof09Dhy3YUat1ylIUVGaCjotAFxE8iGbF6QxLlCWWc=',    // group_id
-    'ssb:feed/bendybutt-v1/YXkE3TikkY4GFMX3lzXUllRkNTbj5E-604AkaO1xbz8=', // feed_id
-  ],
-  tangles: {
-    group: {
-      // ...
-    },
-    members: {
-      // ...
-    }
-  }
-}
-```
-
-The important parts of this message are:
-
-- Which group this is for (this is covered by the `root` and `secret`)
-- Who it's encrypted to (the group, and the feed(s) of people being added)
+- `type` property equal to the string "`group/add-member`"
+- `groupKey` property equal to the base64-encoded string of the group secret key
+- `root` property equal to the ID of the `group/init` message
+- `recps` property containing an array of feed IDs
+  - The first feed ID MUST be the ID of the group feed, as a
+  `ssb:identity/group/` URI
+  - The subsequent feed IDs (at most 15 of them) MUST be the ID of peer(s) being
+  added to the group
 
 The encryption of this message on the additions feed MUST follow the
 [ssb-meta-feeds-dm-spec].

--- a/README.md
+++ b/README.md
@@ -380,7 +380,46 @@ Staltz can see Arj has invited Mix because he's replicating Arj's
 
 ## 5. Security Considerations
 
-TBD
+### 5.1. Degraded confidentiality at scale
+
+As noted in the [private-groups-original-notes], SSB Private Groups are based on
+symmetric encryption and static keys (no key rotation), which means it cannot
+guarantee [perfect-forward-secrecy] neither [post-compromise-security]. This
+makes SSB Private Groups less likely to guarantee confidentiality at scale, when
+a group has dozens or hundreds of members. If any of the members leaks the group
+secret, all past communication in the group is compromised.
+
+This also means that any group member can add new members to the group. They may
+even do so without publishing a `group/add-member` message, which effectively
+allows any group member to invite a third party that will remain undetected by
+existing group members.
+
+SSB Private Groups with several members should thus not be considered
+confidential nor forward secret, and should be used with caution. Our security
+model assumes that the group is as trustworthy as the _least_ trustworthy member
+in the group.
+
+The choice of symmetric encryption (as opposed to, e.g. hash-ratchet or
+double-ratchet) was made because of efficiency. Symmetric encryption means
+adding new members or publishing new content is `O(1)` fast, and the system is
+overall simple to implement.
+
+### 5.2. Membership analysis attacks
+
+A group feed is discoverable only by the group members, because its announcement
+is encrypted. However, an eavesdropper who can replicate a peer's metafeed tree
+will notice the presence of these encrypted message on shard feeds. If the
+eavesdropper can do that for several peers, then they may perform a metadata
+analysis attack where they try to correlate the encrypted messages on the shard
+feeds to the group members.
+
+This can be mitigated by publishing dummy encrypted messages on the shard feed
+at random intervals, with the downside of increasing the size of the shard feed,
+and thus making partial replication heavier.
+
+It is currently unknown how much can be learned from such analysis attack, as
+it depends on the network's complexity, such as number of peers, number of
+groups, and number of relationships between peers.
 
 ## 6. References
 
@@ -393,10 +432,12 @@ TBD
 
 ### 6.2. Informative References
 
+- [private-groups-original-notes]
 - [scuttlebutt-protocol-guide]
 - [ssb-private-group-keys]
 - [ssb-tribes2]
 - [ssb-meta-feeds]
+- [perfect-forward-secrecy]
 
 <!-- References -->
 
@@ -408,3 +449,6 @@ TBD
 [ssb-private-group-keys]: https://github.com/ssbc/ssb-private-group-keys
 [ssb-tribes2]: https://github.com/ssbc/ssb-tribes2
 [ssb-meta-feeds]: https://github.com/ssbc/ssb-meta-feeds
+[private-groups-original-notes]: https://github.com/ssbc/envelope-spec/blob/master/original_notes.md
+[perfect-forward-secrecy]: https://en.wikipedia.org/wiki/Forward_secrecy
+[post-compromise-security]: https://ieeexplore.ieee.org/document/7536374

--- a/README.md
+++ b/README.md
@@ -392,7 +392,8 @@ secret, all past communication in the group is compromised.
 This also means that any group member can add new members to the group. They may
 even do so without publishing a `group/add-member` message, which effectively
 allows any group member to invite a third party that will remain undetected by
-existing group members.
+existing group members. The only signal you might get is that a peer not in the group is asking for
+group leaf feeds that they should not know about.
 
 SSB Private Groups with several members should thus not be considered
 confidential nor forward secret, and should be used with caution. Our security

--- a/README.md
+++ b/README.md
@@ -98,13 +98,14 @@ It's defined in the [private-group-spec] and MUST have at least the following
 fields in its message `content`:
 
 - `type` property equal to the string "`group/add-member`"
-- `groupKey` property equal to the base64-encoded string of the group secret key
-- `root` property equal to the ID of the `group/init` message
+- `version` property equal to the string "`v2`"
+- `secret` property equal to the base64-encoded string of the group secret key
+- `root` property equal to the ID of the `group/init` message, as an SSB URI
 - `recps` property containing an array of feed IDs
   - The first feed ID MUST be the ID of the group feed, as a
   `ssb:identity/group/` URI
   - The subsequent feed IDs (at most 15 of them) MUST be the ID of peer(s) being
-  added to the group
+  added to the group, all as SSB URIs
 
 The encryption of this message on the additions feed MUST follow the
 [ssb-meta-feeds-dm-spec].
@@ -448,6 +449,7 @@ of peers, number of groups, and number of relationships between peers.
 - [envelope-spec]
 - [private-group-spec]
 - [ssb-meta-feeds-dm-spec]
+- [ssb-uri-spec]
 
 ### 6.2. Informative References
 
@@ -471,3 +473,4 @@ of peers, number of groups, and number of relationships between peers.
 [private-groups-original-notes]: https://github.com/ssbc/envelope-spec/blob/master/original_notes.md
 [perfect-forward-secrecy]: https://en.wikipedia.org/wiki/Forward_secrecy
 [post-compromise-security]: https://ieeexplore.ieee.org/document/7536374
+[ssb-uri-spec]: https://github.com/ssbc/ssb-uri-spec

--- a/README.md
+++ b/README.md
@@ -422,6 +422,14 @@ It is currently unknown how much can be learned from such analysis attack, as
 it depends on the network's complexity, such as number of peers, number of
 groups, and number of relationships between peers.
 
+Another way membership information can leak is through replication requests -
+if only Alice, Bob, and Carol ask for feeds A, B, C, and these feeds don't seem to
+be associated with any publicly declared sub-feeds, it might be reasonable to guess
+that Alice, Bob, Carol are all in a group and that A, B, C are their associated feeds
+for that group. We think this can be mitigated through "sympathetic replication"
+(asking friends who aren't in our groups to replicate some of our group feeds) in order
+to add more noise (and replication resilience) to the system. This needs further
+investigation and specification.
 ## 6. References
 
 ### 6.1. Normative References

--- a/README.md
+++ b/README.md
@@ -392,13 +392,12 @@ secret, all past communication in the group is compromised.
 This also means that any group member can add new members to the group. They may
 even do so without publishing a `group/add-member` message, which effectively
 allows any group member to invite a third party that will remain undetected by
-existing group members. The only signal you might get is that a peer not in the group is asking for
-group leaf feeds that they should not know about.
+existing group members. The only signal group members may get is that this third
+party is requesting replication for group feeds that they should not know about.
 
-SSB Private Groups with several members should thus not be considered
-confidential nor forward secret, and should be used with caution. Our security
-model assumes that the group is as trustworthy as the _least_ trustworthy member
-in the group.
+SSB Private Groups with several members should thus be used with caution. Our
+security model assumes that the group is as trustworthy as the _least_
+trustworthy member in the group.
 
 The choice of symmetric encryption (as opposed to, e.g. hash-ratchet or
 double-ratchet) was made because of efficiency. Symmetric encryption means
@@ -414,27 +413,33 @@ eavesdropper can do that for several peers, then they may perform a metadata
 analysis attack where they try to correlate the encrypted messages on the shard
 feeds to the group members.
 
-In the current implementation, we mitigated through how shards are assigned
-per user - because the derivation involves a hash function and a piece of
-content unique to the peer (their root feed id), each peer will have the group
-located in a different shard. This makes it harder to guess which group an 
-announce message was for. 
 This can be mitigated by publishing dummy encrypted messages on the shard feed
 at random intervals, with the downside of increasing the size of the shard feed,
 and thus making partial replication heavier.
 
-It is currently unknown how much can be learned from such analysis attack, as
-it depends on the network's complexity, such as number of peers, number of
-groups, and number of relationships between peers.
+Another mitigation, which is covered by this specification and by
+[ssb-meta-feeds-spec], is how shard feeds are derived for each peer. The
+derivation involves a hash function and a piece of metadata unique to the peer,
+which means that group members will have their group feeds located in a
+different shard. This makes it harder for an eavesdropper to correlate the
+encrypted messages on the shard feeds of the peers it is eavesdropping on.
 
-Another way membership information can leak is through replication requests -
-if only Alice, Bob, and Carol ask for feeds A, B, C, and these feeds don't seem to
-be associated with any publicly declared sub-feeds, it might be reasonable to guess
-that Alice, Bob, Carol are all in a group and that A, B, C are their associated feeds
-for that group. We think this can be mitigated through "sympathetic replication"
-(asking friends who aren't in our groups to replicate some of our group feeds) in order
-to add more noise (and replication resilience) to the system. This needs further
-investigation and specification.
+Another way membership information can leak is through replication requests:
+if only Alice, Bob, and Carol request for feeds A, B, C, and if these feeds
+don't seem to be publicly declared in any metafeed tree, it might be reasonable
+for an eavesdropper to guess that Alice, Bob, Carol are all in a group and that
+A, B, C are group feeds. We think this can be mitigated through "sympathetic
+replication". Sympathetic replication involves asking friendly peers who aren't
+in our groups to replicate some of our group feeds. This adds more noise in
+metadata analysis attacks, and makes it harder to guess who is in a group. It
+also improves replication resilience, because there are more peers replicating
+group feeds, making them more available in the network. Sympathetic replication
+needs further investigation and specification.
+
+It is currently unknown how much can be learned from metadata analysis attacks,
+as it depends on these mitigations and the network's complexity, such as number
+of peers, number of groups, and number of relationships between peers.
+
 ## 6. References
 
 ### 6.1. Normative References

--- a/README.md
+++ b/README.md
@@ -8,12 +8,24 @@ SPDX-License-Identifier: CC-BY-4.0
 
 Version: 1.0
 
-Author: Mix Irving <mix@protozoa.nz>
+Authors: Mix Irving <mix@protozoa.nz>, Andre Staltz <contact@staltz.com>
 
 License: This work is licensed under a Creative Commons Attribution 4.0
 International License.
 
 ## Abstract
+
+This document specifies how SSB private group content is organized in a metafeed
+tree, what data must be encrypted and to whom, and how peers replicate
+group-related portions of the tree.
+
+## 1. Introduction
+
+SSB Private Groups is a symmetric encryption format that allows a large number
+of peers to share a symmetric key and use it to encrypt messages to each other.
+With the wide adoption of private groups, there would be a large volume of
+content that is not readable by the general public, which can cause storage
+problems as that content is replicated in the network.
 
 In order to support partial replication, it is desireable to put different group
 content in different subfeeds. However, we need to have a clear way to discover
@@ -27,86 +39,57 @@ two members. Thus we need to enable _sympathetic replication_, such that peers
 who don't strictly need the group content are incentivized to replicate it
 anyway.
 
-This document specifies how group content is organized in a metafeed tree, what
-data must be encrypted and to whom, and how peers replicate group-related
-portions of the tree.
+Additionally, our metafeed structure should not allow other peers to learn
+which groups a peer is in, unless they are also members of the group.
 
-## Terminology
+Use of metafeeds for groups is described formally in Section 3 and illustrated
+in the examples in Section 4.
+
+## 2. Terminology
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
-## Principles
+## 3. Functional Specification
 
-1. **Group membership should be opaque**
-   - You shouldn't be able to guess who is in a group using public info, such
-   as:
-     - Shard feeds
-     - `groupId` (as ssb-uri)
-2. **Peers should replicate sympathetically**
-   - If a friend has a subfeed dedicated to a group, but I don't belong to that
-   group, it is RECOMMENDED that I replicate that subfeed
-   - May be randomized or subject to sympathy-related parameters
-
-## Specification
-
-This work builds on the [ssb-meta-feeds-spec] (v1).
+Implementations supporting this specification MUST follow the
+[ssb-meta-feeds-spec] version 1.0.
 
 We define two types of feeds that each peer will have:
 
 1. A `group/additions` feed
 2. A "group feed" for each group
 
-```mermaid
-graph TB
+We then define three different flows for how peers can interact with these
+feeds when:
 
-root(root)
-v1(v1)
-5(5) & b(b) & f(f)
-additions(group/additions):::additionsClass
-aalborg(aalborg):::group
-helsinki(helsinki):::group
-wellington(wellington):::group
+1. Creating a new group
+2. Adding a peer to a group
+3. Discovering group membership
 
-root --> v1 --> 5 --> helsinki
-         v1 --> b --> additions
-         v1 --> f --> aalborg
-                f --> wellington
-
-classDef default stroke:none;
-classDef additionsClass fill: #BF2669, stroke:none, color:white;
-classDef group fill: #702A8C, stroke: none, color:white;
-```
-
-_Diagram showing an example layout of group-related feeds. Note that the shards
-in your use-case will likely not be those shown, see how they are determined
-below._
-
-### 1. The additions feed
+### 3.1. The group/additions feed
 
 The purpose of this feed is to hold messages for coordination of joining groups.
+It represents the record of all peers the user had added to groups.
 
-- 1.1 Each peer running this spec MUST have an additions feed
-- 1.2 Each peer MUST deterministically place their additions feed as a subfeed,
-such that:
-  - Their additions feed is a direct subfeed of a shard feed
-  - The shard feed is a subfeed of the v1 subfeed, and derived from the string
-  `group/additions` according to the v1 tree structure specified in
+- 3.1.1 Each peer running this spec MUST have an additions feed
+- 3.1.2 Each peer MUST deterministically place their additions feed as a subfeed
+of a shard feed, such that:
+  - The shard feed is derived from the string "`group/additions`" according to
+  the v1 tree structure specified in
   [ssb-meta-feeds-spec].
   - The `metafeeds/add/derived` message announcing the additions feed
     - MUST have `feedpurpose` equal to the string `group/additions`,
     - MUST be of feed format `classic`
-    - MUST have `metadata` following the [ssb-meta-feeds-dm-spec] section 1
+    - MUST have `metadata` following the [ssb-meta-feeds-dm-spec] Section 1
     - MUST NOT be encrypted
-- 1.3 If a peer A wants to add another peer B in a group, then A MUST replicate
+- 3.1.3 If a peer A wants to add another peer B in a group, then A MUST replicate
 B's additions feed and B must replicate A's additions feed
-- 1.4 All messages published on the additions feed MUST be encrypted with [box2]
-encryption, also known as "envelope spec".
+- 3.1.4 All messages published on the additions feed MUST be "`group/add-member`"
+messages encrypted with [envelope-spec] encryption
   - See details below
-- 1.5 There MUST be at most one additions feed per metafeed tree
-  - This feed represents the record of all people joining each group and must
-  not be lost
+- 3.1.5 There MUST be at most one additions feed per metafeed tree
 
 #### `group/add-member` messages
 
@@ -142,27 +125,31 @@ The important parts of this message are:
 The encryption of this message on the additions feed MUST follow the
 [ssb-meta-feeds-dm-spec].
 
-### 2. Group feeds
+### 3.2. Group feeds
 
-The purpose of this feed is to hold the groups messages.
+The purpose of this feed is to hold the messages the user publishes for a
+specific group. It represents all the activity this user has in a group. The
+user has at most one group feed for each group they are a member of.
 
 Each group feed MUST be a direct subfeed of a shard feed, where the shard is
-derived using the base64 encoded
+derived using the base64 encoded *group secret*.
 
-- 2.1 Each peer that is a member of a group MAY have a group feed for that group
-- 2.2 Each peer MUST deterministically place their group feed as a subfeed, such
-that:
-  - Their group feed is a direct subfeed of a shard feed
-  - The shard feed is a subfeed of the v1 subfeed, and derived from the base64
-  encoded string of the group secret key `secret` according to the v1 tree
-  structure specified in [ssb-meta-feeds-spec].
+- 3.2.1 Each peer that is a member of a group MAY have a group feed for that
+group
+  - It is not compulsory to have a group feed for a group the user is a member
+  of, because the user may not have confirmed their participation in the group
+  after being added to it.
+- 3.2.2 Each peer MUST deterministically place their group feed as a subfeed of
+a shard feed, such that:
+  - The shard feed is derived from the base64 encoded string of the group secret
+  according to the v1 tree structure specified in [ssb-meta-feeds-spec].
   - The `metafeeds/add/derived` message announcing the group feed
     - MUST have `feedpurpose` equal to the base64 encoded group secret
-    - MUST be encrypted with the group secret, using [box2] encryption
-- 2.3 Each group member SHOULD replicate the group feeds of all other known
-group members
-- 2.4 All content on the group feed MUST be encrypted with the group secret key,
-using [box2] encryption, also known as "envelope spec".
+    - MUST be encrypted with the group secret, using [envelope-spec] encryption
+- 3.2.3 Each group member SHOULD replicate the group feeds of all other group
+members they know of
+- 3.2.4 All content on the group feed MUST be encrypted with the group secret
+key, using [envelope-spec] encryption
 
 <details>
   <summary>Details about the shard feed</summary>
@@ -170,10 +157,11 @@ using [box2] encryption, also known as "envelope spec".
 The shard feed is derived by the base64 encoded group secret.
 
 We cannot use the group `id`, as this is publicly known, which would give
-attackers a way to test if people are in the group (breaking Principle 1.)
+attackers a way to test if people are in the group (breaking membership
+confidentiality).
 
-We choose the the group `secret` because it is a value known only to those
-already in the group.
+We choose the group `secret` because it is a value known only to those already
+in the group.
 
   </div>
 </details>
@@ -182,16 +170,12 @@ already in the group.
   <summary>Details about the group feed</summary>
   <div>
 
-- `feedpurpose = secret` where `secret` is the base64 encoded group secret
-- `feedFormat = classic`
-- The `metafeed/add/derived` message on the shard feed MUST be encrypted with
-this group's secret
-
 We need a `feedpurpose` which is unique to the group, which the group secret is.
 
 We cannot use the group `id`, because this is derived using the group init
 message, which does not exist until our feed exists. We encrypt this announce
-message so as not to leak the `secret` AND to protect group membership.
+message so as not to leak the `secret` and to protect membership
+confidentiality.
 
 For sympathetic replication we will therefore need a distinct type of
 announcement.
@@ -199,9 +183,72 @@ announcement.
   </div>
 </details>
 
-## Flows
+### 3.3. Creating a new group
 
-### 1. Creating a group
+To create a new group, a peer should perform all of the following steps
+successfully:
+
+- 3.3.1. MUST create a new symmetric group key, also known as the group secret,
+which MUST have at least 32 bytes of cryptographically secure random data
+- 3.3.2. MUST create a new group feed using this symmetric group key, as
+described in Section 3.2
+- 3.3.3. MUST publish a `group/init` message on the group feed, as described in
+the [private-group-spec]
+- 3.3.3. SHOULD create a group/additions feed, as described in Section 3.1,
+unless there is already one for this metafeed
+- 3.3.4. SHOULD publish a `group/add-member` message on the group/additions feed
+to add themselves to the group, as described in Section 3.1
+
+### 3.4. Adding a peer to a group
+
+To add other peers to a group, a peer MUST publish a `group/add-member` message
+on the group/additions feed addressed to the other peer, as described in Section
+3.1. This message must be encrypted following the [ssb-meta-feeds-dm-spec].
+
+### 3.5. Discovering group membership
+
+To discover the members of a group, a peer MUST perform the following steps:
+
+- 3.5.1. MUST replicate the group/additions feed of other peers, either on the
+basis of friendship or because they are a known member of a group
+- 3.5.2. MUST decrypt some or all `group/add-member` messages on the
+group/additions feed
+- 3.5.3. Each decrypted `group/add-member` message reveals, in the `recps`
+field, the newly added member(s) and the group identifier, allowing the user to
+infer that the newly added member(s) are members of the group
+
+Upon a peer discovering that they are a member of a group, they MAY create a
+group feed if they do not already have one. This allows them to publish messages
+to the group.
+
+## 4. Examples
+
+The following diagram illustrates the structure of a metafeed tree for a peer,
+"Staltz", who is a member of three groups: "helsinki", "aalborg", and
+"wellington".
+
+```mermaid
+graph TB
+
+root(root)
+v1(v1)
+5(5) & b(b) & f(f)
+additions(group/additions):::additionsClass
+aalborg(aalborg):::group
+helsinki(helsinki):::group
+wellington(wellington):::group
+
+root --> v1 --> 5 --> helsinki
+         v1 --> b --> additions
+         v1 --> f --> aalborg
+                f --> wellington
+
+classDef default stroke:none;
+classDef additionsClass fill: #BF2669, stroke:none, color:white;
+classDef group fill: #702A8C, stroke: none, color:white;
+```
+
+### 4.1. Creating a group
 
 Staltz starts up his application. We assume he has already created his
 `group/additions` feed (following the spec above). In his application he creates
@@ -245,7 +292,7 @@ classDef group fill: #702A8C, stroke: none, color:white;
 
 _Diagram showing Staltz feed state from his perspective_
 
-### 2. Group creator invites someone
+### 4.2. Group creator invites someone
 
 Staltz wants to invite his friend Arj to the group he set up, so he publishes a
 `group/add-member` message (which contains the group `secret`) on his
@@ -336,7 +383,7 @@ feed, and read that the `feedpurpose` is the `groupKey`. Staltz knows which
 shard feed to watch for the announcement, because Arj's shard feed is
 deterministically derived with information Staltz is aware of.
 
-### 3. Non-group creator invites someone
+### 4.3. Non-group creator invites someone
 
 Arj now wants to invite Mix to the "helsinki" group. He follows the same pattern
 as in (2), but now as the inviter.
@@ -347,9 +394,33 @@ knows Staltz is part of the group because all `group/add-member` messages have
 Staltz can see Arj has invited Mix because he's replicating Arj's
 "group/additions" feed, so Staltz starts replicating Mix's group feed.
 
+## 5. Security Considerations
+
+TBD
+
+## 6. References
+
+### 6.1. Normative References
+
+- [ssb-meta-feeds-spec]
+- [envelope-spec]
+- [private-group-spec]
+- [ssb-meta-feeds-dm-spec]
+
+### 6.2. Informative References
+
+- [scuttlebutt-protocol-guide]
+- [ssb-private-group-keys]
+- [ssb-tribes2]
+- [ssb-meta-feeds]
+
 <!-- References -->
 
+[private-group-spec]: https://github.com/ssbc/private-group-spec
 [ssb-meta-feeds-spec]: https://github.com/ssbc/ssb-meta-feeds-spec
-[box2]: https://github.com/ssbc/envelope-spec/
-[pivate-group-spec]: https://github.com/ssbc/private-group-spec
+[envelope-spec]: https://github.com/ssbc/envelope-spec/
 [ssb-meta-feeds-dm-spec]: https://github.com/ssbc/ssb-meta-feeds-dm-spec
+[scuttlebutt-protocol-guide]: https://ssbc.github.io/scuttlebutt-protocol-guide/
+[ssb-private-group-keys]: https://github.com/ssbc/ssb-private-group-keys
+[ssb-tribes2]: https://github.com/ssbc/ssb-tribes2
+[ssb-meta-feeds]: https://github.com/ssbc/ssb-meta-feeds


### PR DESCRIPTION
I've been browsing RFCs such as [webfinger](https://www.rfc-editor.org/rfc/rfc7033) and I noticed they typically have:

- Abstract
- Introduction
- Specification
- Examples (sometimes, not always, and it's separate from the Specification section)
- Security Considerations
- Normative References (other links you must abide by, "dependencies")
- Informative References (just other interesting and related links)

Also, this PR merged https://github.com/ssbc/ssb-meta-feeds-group-spec/pull/14 so we now have the Security Considerations section.